### PR TITLE
fix: resolve #8 — 🟡 [AI-QA] ObsidianWatcher uses insertOutputMetric (overwrite) instead of addOutputMetric (accumulate)

### DIFF
--- a/Sources/UseTrackCollector/Watchers/ObsidianWatcher.swift
+++ b/Sources/UseTrackCollector/Watchers/ObsidianWatcher.swift
@@ -85,9 +85,9 @@ class ObsidianWatcher {
         }
 
         do {
-            try dbManager.insertOutputMetric(
+            try dbManager.addOutputMetric(
                 date: today, metricType: "obsidian_words",
-                value: Double(totalNewWords),
+                delta: Double(totalNewWords),
                 details: detailsJSON
             )
             print("[ObsidianWatcher] +\(totalNewWords) words in \(changedFiles.count) files")


### PR DESCRIPTION
## Summary
Auto-fix for #8

## Changes
- fix: resolve issue #8 — use addOutputMetric to accumulate word counts

## Issue Reference
Closes #8

---
🤖 *此 PR 由 AI Fix Agent 自动创建*