### PR TITLE
fix: resolve #16 — 🟡 [AI-QA] InputWatcher doesn't reset timer on stop/restart cycle

### DIFF
--- a/Sources/UseTrackCollector/Watchers/InputWatcher.swift
+++ b/Sources/UseTrackCollector/Watchers/InputWatcher.swift
@@ -25,6 +25,13 @@ class InputWatcher {
     }
 
     func start() {
+        // Reset counters to avoid carrying over stale counts from a previous period
+        serialQueue.sync {
+            keystrokeCount = 0
+            mouseClickCount = 0
+            scrollCount = 0
+        }
+
         // Monitor keystrokes (count only, not content)
         if let monitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown, handler: { [weak self] _ in
             self?.serialQueue.async { self?.keystrokeCount += 1 }
@@ -54,6 +61,11 @@ class InputWatcher {
 
     func stop() {
         timer?.invalidate()
+        timer = nil
+
+        // Flush any pending counts before removing monitors
+        recordAndReset()
+
         for monitor in eventMonitors { NSEvent.removeMonitor(monitor) }
         eventMonitors.removeAll()
     }


### PR DESCRIPTION
## Summary
Auto-fix for #16

## Changes
- fix: resolve issue #16 — flush pending counts on stop and reset counters on start

## Issue Reference
Closes #16

---
🤖 *此 PR 由 AI Fix Agent 自动创建*