### PR TITLE
fix: resolve #17 — 🟡 [AI-QA] WindowWatcher and AttentionScorer can be started multiple times without stopping

### DIFF
--- a/Sources/UseTrackCollector/Attention/MouseTracker.swift
+++ b/Sources/UseTrackCollector/Attention/MouseTracker.swift
@@ -33,6 +33,9 @@ class MouseTracker {
     private let retentionInterval: TimeInterval = 60  // Keep events for 60 seconds
 
     func start() {
+        // Guard against double-start: remove any existing monitors first
+        stop()
+
         // Monitor mouse movement (global, across all apps)
         if let monitor = NSEvent.addGlobalMonitorForEvents(matching: .mouseMoved, handler: { [weak self] event in
             self?.handleMouseMove(event)

--- a/Sources/UseTrackCollector/Watchers/AFKWatcher.swift
+++ b/Sources/UseTrackCollector/Watchers/AFKWatcher.swift
@@ -34,6 +34,9 @@ class AFKWatcher {
     }
 
     func start() {
+        // Guard against double-start: invalidate any existing timer first
+        stop()
+
         timer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] _ in
             self?.checkIdleState()
         }

--- a/Sources/UseTrackCollector/Watchers/InputWatcher.swift
+++ b/Sources/UseTrackCollector/Watchers/InputWatcher.swift
@@ -25,6 +25,9 @@ class InputWatcher {
     }
 
     func start() {
+        // Guard against double-start: clean up existing monitors and timer first
+        stop()
+
         // Reset counters to avoid carrying over stale counts from a previous period
         serialQueue.sync {
             keystrokeCount = 0

--- a/Sources/UseTrackCollector/Watchers/WindowWatcher.swift
+++ b/Sources/UseTrackCollector/Watchers/WindowWatcher.swift
@@ -63,6 +63,8 @@ class WindowWatcher {
     }
 
     func start() {
+        // Guard against double-start: clean up any existing timers first
+        stop()
         scheduleTimer()
         // Fire immediately on start
         checkWindowTitle()


### PR DESCRIPTION
## Summary
Auto-fix for #17

## Changes
- fix: resolve issue #17 — guard start() against double-start in all watchers

## Issue Reference
Closes #17

---
🤖 *此 PR 由 AI Fix Agent 自动创建*