### PR TITLE
fix: resolve #7 — 🟠 [AI-QA] updateLastActivityDuration updates wrong row in concurrent scenarios

### DIFF
--- a/Sources/UseTrackCollector/Storage/DatabaseManager.swift
+++ b/Sources/UseTrackCollector/Storage/DatabaseManager.swift
@@ -343,16 +343,20 @@ class DatabaseManager {
         }
     }
 
-    /// 更新最近一条活动事件的持续时间（当下一个事件到达时回填）
-    func updateLastActivityDuration(durationSeconds: Double) throws {
+    /// 更新指定活动事件的持续时间（当下一个事件到达时回填）
+    /// - Parameters:
+    ///   - rowId: 要更新的活动事件的行 ID
+    ///   - durationSeconds: 持续时间（秒）
+    func updateActivityDuration(rowId: Int64, durationSeconds: Double) throws {
         try dbQueue.sync {
             try db.run(
                 """
                 UPDATE activity_stream
                 SET duration_s = ?
-                WHERE id = (SELECT MAX(id) FROM activity_stream)
+                WHERE id = ?
                 """,
-                durationSeconds
+                durationSeconds,
+                rowId
             )
         }
     }

--- a/Sources/UseTrackCollector/Watchers/AppWatcher.swift
+++ b/Sources/UseTrackCollector/Watchers/AppWatcher.swift
@@ -18,6 +18,8 @@ class AppWatcher {
     private let dbManager: DatabaseManager
     private var lastSwitchTime: Date?
     private var lastAppName: String?
+    /// Row ID of the last app_switch event inserted, used for precise duration backfill.
+    private var lastActivityRowId: Int64?
 
     /// System processes that should never be recorded as user activity.
     /// These are macOS internal processes that become "frontmost" during
@@ -73,7 +75,7 @@ class AppWatcher {
                     meta: ["bundle_id": bundleId],
                     category: category
                 )
-                try? dbManager.insertActivity(event)
+                lastActivityRowId = try? dbManager.insertActivity(event)
             }
         }
 
@@ -118,10 +120,10 @@ class AppWatcher {
     }
 
     private func recordSwitch(appName: String, bundleId: String, windowTitle: String?, at time: Date) {
-        // 1. Backfill duration of previous event
-        if let lastTime = lastSwitchTime {
+        // 1. Backfill duration of previous event using its specific row ID
+        if let lastTime = lastSwitchTime, let rowId = lastActivityRowId {
             let duration = time.timeIntervalSince(lastTime)
-            try? dbManager.updateLastActivityDuration(durationSeconds: duration)
+            try? dbManager.updateActivityDuration(rowId: rowId, durationSeconds: duration)
         }
 
         // 2. Get category from app_rules
@@ -139,11 +141,12 @@ class AppWatcher {
             category: category
         )
 
-        // 4. Write to database
+        // 4. Write to database and store row ID for future duration backfill
         do {
-            let _ = try dbManager.insertActivity(event)
+            lastActivityRowId = try dbManager.insertActivity(event)
         } catch {
             print("[AppWatcher] Error inserting activity: \(error)")
+            lastActivityRowId = nil
         }
 
         // 5. Update state


### PR DESCRIPTION
## Summary
Auto-fix for #7

## Changes
- fix: resolve issue #7 — use specific rowId for duration backfill instead of MAX(id)

## Issue Reference
Closes #7

---
🤖 *此 PR 由 AI Fix Agent 自动创建*