### PR TITLE
fix: resolve #71 — 🟡 [AI-QA] AppWatcher.lastAppName tracks redacted name causing missed events

### DIFF
--- a/Sources/UseTrackCollector/Watchers/AppWatcher.swift
+++ b/Sources/UseTrackCollector/Watchers/AppWatcher.swift
@@ -111,6 +111,9 @@ class AppWatcher {
             return
         }
 
+        // Update lastAppName with the real name for accurate deduplication
+        lastAppName = appName
+
         // Check sensitive app blacklist
         if dbManager.isSensitiveApp(appName: appName) {
             let category = dbManager.getCategoryForApp(appName: appName)
@@ -152,6 +155,5 @@ class AppWatcher {
 
         // 5. Update state
         lastSwitchTime = time
-        lastAppName = appName
     }
 }


### PR DESCRIPTION
## Summary
Auto-fix for #71

## Changes
- fix: resolve issue #71 — track real app name for deduplication of sensitive apps

## Issue Reference
Closes #71

---
🤖 *此 PR 由 AI Fix Agent 自动创建*