### PR TITLE
fix: resolve #72 — 🟡 [AI-QA] MergedDB._dates_from_period returns exclusive end_date causing missed remote DBs

### DIFF
--- a/python/src/usetrack/sync.py
+++ b/python/src/usetrack/sync.py
@@ -257,7 +257,7 @@ class MergedDB(UseTrackDB):
         """Get merged activity summary from local + remote DBs."""
         local = await super().get_activity_summary(period)
         start, end = self._parse_period(period)
-        start_date, end_date = start[:10], end[:10]
+        start_date, end_date = self._dates_from_period(period)
 
         remote_dbs = self._find_remote_dbs(start_date, end_date)
         if not remote_dbs:
@@ -478,7 +478,7 @@ class MergedDB(UseTrackDB):
         """Get merged output metrics."""
         local = await super().get_output_metrics(period)
         start, end = self._parse_period(period)
-        start_date, end_date = start[:10], end[:10]
+        start_date, end_date = self._dates_from_period(period)
 
         remote_dbs = self._find_remote_dbs(start_date, end_date)
         if not remote_dbs:


### PR DESCRIPTION
## Summary
Auto-fix for #72

## Changes
- fix: resolve issue #72 — use _dates_from_period to avoid exclusive end_date in remote DB lookups

## Issue Reference
Closes #72

---
🤖 *此 PR 由 AI Fix Agent 自动创建*