### PR TITLE
fix: resolve #75 — 🟡 [AI-QA] TrackingEngine wake-from-sleep may miss locked state

### DIFF
--- a/Sources/UseTrackCollector/TrackingEngine.swift
+++ b/Sources/UseTrackCollector/TrackingEngine.swift
@@ -221,8 +221,15 @@ class TrackingEngine {
             forName: NSWorkspace.didWakeNotification,
             object: nil, queue: .main
         ) { [weak self] _ in
-            // 唤醒后可能还是锁屏状态，先转 active，锁屏通知会再修正
-            self?.transition(to: .active)
+            // 唤醒后检查屏幕是否仍处于锁定状态，避免短暂误启动 watchers
+            let isLocked: Bool = {
+                if let dict = CGSessionCopyCurrentDictionary() as? [String: Any],
+                   let locked = dict["CGSSessionScreenIsLocked"] as? Bool {
+                    return locked
+                }
+                return false
+            }()
+            self?.transition(to: isLocked ? .locked : .active)
         }
         observers.append(wakeObs)
     }


### PR DESCRIPTION
## Summary
Auto-fix for #75

## Changes
- fix: resolve issue #75 — check screen lock state on wake before transitioning

## Issue Reference
Closes #75

---
🤖 *此 PR 由 AI Fix Agent 自动创建*