### PR TITLE
fix: resolve #79 — 🟡 [AI-QA] MergedDB._find_remote_dbs uses wrong end_date boundary

### DIFF
--- a/python/src/usetrack/sync.py
+++ b/python/src/usetrack/sync.py
@@ -488,7 +488,7 @@ class MergedDB(UseTrackDB):
             rows = await self._query_remote_db(
                 db_path,
                 """SELECT metric_type, SUM(value) as total FROM output_metrics
-                WHERE date >= ? AND date < ? GROUP BY metric_type""",
+                WHERE date >= ? AND date <= ? GROUP BY metric_type""",
                 (start_date, end_date),
             )
             for r in rows:


### PR DESCRIPTION
## Summary
Auto-fix for #79

## Changes
- fix: resolve issue #79 — use inclusive end_date boundary in get_output_metrics SQL query

## Issue Reference
Closes #79

---
🤖 *此 PR 由 AI Fix Agent 自动创建*