### PR TITLE
fix: resolve #84 — 🟡 [AI-QA] TrackingEngine wake-from-sleep race condition with lock screen

### DIFF
--- a/Sources/UseTrackCollector/TrackingEngine.swift
+++ b/Sources/UseTrackCollector/TrackingEngine.swift
@@ -143,12 +143,14 @@ class TrackingEngine {
             windowWatcher.stop()
             inputWatcher.stop()
             mouseTracker.stop()
-            // AppWatcher 和 AFKWatcher 保持（检测解锁）
+            afkWatcher.stop()
+            // AppWatcher 保持（NSWorkspace 通知在解锁后自动恢复）
 
         case (.locked, .active):
             windowWatcher.start()
             inputWatcher.start()
             mouseTracker.start()
+            afkWatcher.start()
 
         // ---- 睡眠 ----
         case (_, .asleep):


### PR DESCRIPTION
## Summary
Auto-fix for #84

## Changes
- fix: resolve issue #84 — stop afkWatcher on lock and restart on unlock

## Issue Reference
Closes #84

---
🤖 *此 PR 由 AI Fix Agent 自动创建*