### PR TITLE
fix: resolve #100 — 🟡 [AI-QA] MergedDB query uses inconsistent date boundary (<=) vs local DB (<)

### DIFF
--- a/python/src/usetrack/sync.py
+++ b/python/src/usetrack/sync.py
@@ -487,7 +487,7 @@ class MergedDB(UseTrackDB):
             rows = await self._query_remote_db(
                 db_path,
                 """SELECT metric_type, SUM(value) as total FROM output_metrics
-                WHERE date >= ? AND date <= ? GROUP BY metric_type""",
+                WHERE date >= ? AND date < ? GROUP BY metric_type""",
                 (start_date, end_date),
             )
             for r in rows:


### PR DESCRIPTION
## Summary
Auto-fix for #100

## Changes
- fix: resolve issue #100 — use consistent half-open date interval in MergedDB remote query

## Issue Reference
Closes #100

---
🤖 *此 PR 由 AI Fix Agent 自动创建*