### PR TITLE
fix: resolve #101 — 🟡 [AI-QA] TrackingEngine state machine missing idle→asleep and idle→locked transitions

### DIFF
--- a/Sources/UseTrackCollector/TrackingEngine.swift
+++ b/Sources/UseTrackCollector/TrackingEngine.swift
@@ -138,6 +138,13 @@ class TrackingEngine {
             windowWatcher.start()
 
         // ---- 锁屏 ----
+        case (.idle, .locked):
+            // Already stopped windowWatcher in idle transition; stop remaining watchers
+            inputWatcher.stop()
+            mouseTracker.stop()
+            afkWatcher.stop()
+            // Note: idle session stays open; will be closed when transitioning back to .active
+
         case (_, .locked):
             // 锁屏时暂停所有昂贵的轮询
             windowWatcher.stop()
@@ -147,12 +154,20 @@ class TrackingEngine {
             // AppWatcher 保持（NSWorkspace 通知在解锁后自动恢复）
 
         case (.locked, .active):
+            // If user was idle before locking, close the stale idle session (Issue #101)
+            afkWatcher.forceEndIdle()
             windowWatcher.start()
             inputWatcher.start()
             mouseTracker.start()
             afkWatcher.start()
 
         // ---- 睡眠 ----
+        case (.idle, .asleep):
+            // Already stopped windowWatcher in idle transition; stop remaining watchers
+            inputWatcher.stop()
+            mouseTracker.stop()
+            afkWatcher.stop()
+
         case (_, .asleep):
             // 系统睡眠：全部暂停
             windowWatcher.stop()
@@ -162,6 +177,8 @@ class TrackingEngine {
             // AppWatcher 保持（NSWorkspace 通知在唤醒后自动恢复）
 
         case (.asleep, .active):
+            // If user was idle before sleep, close the stale idle session (Issue #101)
+            afkWatcher.forceEndIdle()
             windowWatcher.start()
             inputWatcher.start()
             mouseTracker.start()

--- a/Sources/UseTrackCollector/Watchers/AFKWatcher.swift
+++ b/Sources/UseTrackCollector/Watchers/AFKWatcher.swift
@@ -47,6 +47,37 @@ class AFKWatcher {
         timer = nil
     }
 
+    /// Force-end an active idle session, writing idle_end to DB and resetting internal state.
+    /// Called by TrackingEngine when resuming from .asleep/.locked to .active,
+    /// to ensure no stale idle session is left unclosed (see Issue #101).
+    func forceEndIdle() {
+        guard isIdle else { return }
+        let now = Date()
+        let idleDuration = idleStartTime.map { now.timeIntervalSince($0) } ?? 0
+
+        isIdle = false
+
+        let event = ActivityEvent(
+            id: nil,
+            timestamp: now,
+            activity: "idle_end",
+            appName: nil,
+            windowTitle: nil,
+            durationSeconds: idleDuration,
+            meta: ["idle_duration_s": String(Int(idleDuration)), "source": "force_end"],
+            category: nil
+        )
+
+        do {
+            let _ = try dbManager.insertActivity(event)
+            print("[AFKWatcher] Force-ended idle session (was idle for \(Int(idleDuration))s)")
+        } catch {
+            print("[AFKWatcher] Error recording forced idle_end: \(error)")
+        }
+
+        idleStartTime = nil
+    }
+
     private func checkIdleState() {
         let idleSeconds = getIdleTime()
 


### PR DESCRIPTION
## Summary
Auto-fix for #101

## Changes
- fix: resolve issue #101 — close stale idle sessions on asleep/locked→active transitions

## Issue Reference
Closes #101

---
🤖 *此 PR 由 AI Fix Agent 自动创建*