### PR TITLE
fix: resolve #102 — 🟡 [AI-QA] Discord webhook script sends report even when WEBHOOK_URL is empty string

### DIFF
--- a/scripts/daily_discord_report.py
+++ b/scripts/daily_discord_report.py
@@ -198,9 +198,15 @@ def build_discord_payload(summary, focus, distraction, output, dw_trend, switch_
 
 
 def send_to_discord(payload: dict):
+    if not WEBHOOK_URL or not WEBHOOK_URL.strip():
+        print("❌ WEBHOOK_URL 为空，无法发送")
+        return False
+    if not WEBHOOK_URL.strip().startswith("https://discord.com/api/webhooks/"):
+        print("❌ WEBHOOK_URL 格式无效，必须以 'https://discord.com/api/webhooks/' 开头")
+        return False
     data = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
-        WEBHOOK_URL,
+        WEBHOOK_URL.strip(),
         data=data,
         headers={
             "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
Auto-fix for #102

## Changes
- fix: resolve issue #102 — validate WEBHOOK_URL in send_to_discord()

## Issue Reference
Closes #102

---
🤖 *此 PR 由 AI Fix Agent 自动创建*