### PR TITLE
fix: resolve #104 — 🟡 [AI-QA] Browser extension flushPendingUrls can duplicate messages on partial failure

### DIFF
--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -116,13 +116,11 @@ async function flushPendingUrls() {
 
     const remaining = [];
 
-    for (const message of pending) {
-        const sent = await sendNativeMessage(message);
+    for (let i = 0; i < pending.length; i++) {
+        const sent = await sendNativeMessage(pending[i]);
         if (!sent) {
             // Native host still unavailable, keep remaining messages and stop
-            remaining.push(message);
-            // Don't try further messages if the host is down
-            remaining.push(...pending.slice(pending.indexOf(message) + 1));
+            remaining.push(...pending.slice(i));
             break;
         }
     }


### PR DESCRIPTION
## Summary
Auto-fix for #104

## Changes
- fix: resolve issue #104 — use index-based loop in flushPendingUrls to prevent message duplication

## Issue Reference
Closes #104

---
🤖 *此 PR 由 AI Fix Agent 自动创建*