### PR TITLE
fix: resolve #105 — 🟡 [AI-QA] AppWatcher records category for sensitive app using real app name before redaction

### DIFF
--- a/Sources/UseTrackCollector/Watchers/AppWatcher.swift
+++ b/Sources/UseTrackCollector/Watchers/AppWatcher.swift
@@ -116,8 +116,7 @@ class AppWatcher {
 
         // Check sensitive app blacklist
         if dbManager.isSensitiveApp(appName: appName) {
-            let category = dbManager.getCategoryForApp(appName: appName)
-            recordSwitch(appName: "[Redacted]", bundleId: bundleId, windowTitle: nil, at: now, categoryOverride: category)
+            recordSwitch(appName: "[Redacted]", bundleId: bundleId, windowTitle: nil, at: now, categoryOverride: "sensitive")
         } else {
             recordSwitch(appName: appName, bundleId: bundleId, windowTitle: nil, at: now)
         }


### PR DESCRIPTION
## Summary
Auto-fix for #105

## Changes
- fix: resolve issue #105 — avoid leaking sensitive app info through category lookup

## Issue Reference
Closes #105

---
🤖 *此 PR 由 AI Fix Agent 自动创建*